### PR TITLE
Fix pyproject toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [0.8.1]
+### Fixed
+fix unbumped pyproject.toml
+
 ## [0.8.0]
 ### Added
 Sample sheet validation models for both bcl2fastq and dragen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgmodels"
-version = "0.7.0"
+version = "v0.8.0"
 description = "Models used at clinical genomics"
 authors = ["moonso <mans.magnusson@scilifelab.se>"]
 readme = "README.md"


### PR DESCRIPTION
### This PR adds | fixes:
- pyproject.toml was no correctly bumped to version `0.8.0` in a previous PR

- [x] Code approved by MM
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
