### PR TITLE
Add taxprofiler to pipeline options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Try to use the following format:
 ### Fixed
 -->
 
+## [0.12.0]
+
+### Added [cg]
+- Adds taxprofiler to pipeline options
 ## [0.11.0]
 ### Added [cg]
 - Adds RNAFUSION to pipeline options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Try to use the following format:
 -->
 
 ## [0.12.0]
-
 ### Added [cg]
 - Adds taxprofiler to pipeline options
 ## [0.11.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Try to use the following format:
 ## [0.12.0]
 ### Added [cg]
 - Adds taxprofiler to pipeline options
+
 ## [0.11.0]
 ### Added [cg]
 - Adds RNAFUSION to pipeline options

--- a/cgmodels/cg/constants.py
+++ b/cgmodels/cg/constants.py
@@ -21,3 +21,4 @@ class Pipeline(StrEnum):
     RSYNC: str = "rsync"
     SARS_COV_2: str = "sars-cov-2"
     SPRING: str = "spring"
+    TAXPROFILER: str = "taxprofiler"


### PR DESCRIPTION
### This PR adds | fixes:
-  Adds taxprofiler to pipeline options

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
