### PR TITLE
Update deprecated workflow actions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
  build-n-publish:
   name: Build and publish Python distribution to PyPI
-  runs-on: ubuntu-18.04
+  runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
      uses: actions/checkout@v2

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,7 +6,7 @@ on:
    - created
 
 jobs:
-   build-n-publish:
+ build-n-publish:
   name: Build and publish Python distribution to PyPI
   runs-on: ubuntu-latest
   steps:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -11,10 +11,10 @@ jobs:
   runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v2
+     uses: actions/checkout@v3
 
    - name: Set up Python 3.7
-     uses: actions/setup-python@v2
+     uses: actions/setup-python@v4
      with:
       python-version: 3.7
 

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,7 +6,7 @@ on:
    - created
 
 jobs:
- build-n-publish:
+   build-n-publish:
   name: Build and publish Python distribution to PyPI
   runs-on: ubuntu-latest
   steps:


### PR DESCRIPTION
### This PR adds | fixes:
 - The GHaction for publishing to PyPI is being queued with the message:
`Waiting for a runner to pick up this job`

- Based on this [post](https://stackoverflow.com/questions/70959954/error-waiting-for-a-runner-to-pick-up-this-job-using-github-actions), GitHub stopped supporting Ubuntu 18.04 on April 1, 2023.
 
- This PR replaces the Ubuntu 18.04 with Ubuntu latest and the actions/checkout like in [cg workflow](https://github.com/Clinical-Genomics/cg/blob/master/.github/workflows/build_and_publish.yml)

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
